### PR TITLE
feat: enable file deletion from explorer

### DIFF
--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -40,6 +40,7 @@ fn main() {
             read_directory,
             read_file,
             write_file,
+            delete_file,
             create_terminal,
             close_terminal,
             start_voice_session,

--- a/apps/desktop/src/components/explorer/FileExplorerPanel.tsx
+++ b/apps/desktop/src/components/explorer/FileExplorerPanel.tsx
@@ -10,7 +10,8 @@ import {
   RefreshCw,
   Search,
   ChevronRight,
-  ChevronDown
+  ChevronDown,
+  Trash2
 } from 'lucide-react'
 import { invoke } from '@tauri-apps/api/core'
 import { useAppStore } from '../../stores/appStore'
@@ -49,7 +50,7 @@ export function FileExplorerPanel() {
   const [currentPath, setCurrentPath] = useState('/Users')
   const [selectedFile, setSelectedFile] = useState<string | null>(null)
   const [gitStatuses, setGitStatuses] = useState<Map<string, GitFileStatus>>(new Map())
-  const { settings } = useAppStore()
+  const { settings, deleteFile } = useAppStore()
   
   useEffect(() => {
     loadDirectory(currentPath)
@@ -278,29 +279,52 @@ export function FileExplorerPanel() {
     loadDirectory(currentPath)
     loadGitStatus(currentPath)
   }
+
+  const handleDeleteSelected = async () => {
+    if (!selectedFile) return
+    if (confirm(`Delete ${selectedFile}?`)) {
+      try {
+        await deleteFile(selectedFile)
+        setSelectedFile(null)
+        await loadDirectory(currentPath)
+        await loadGitStatus(currentPath)
+      } catch (error) {
+        console.error('Failed to delete file:', error)
+      }
+    }
+  }
   
   return (
     <div className="flex flex-col h-full bg-black">
       {/* Header */}
       <div className="px-3 py-2 border-b border-gray-900">
-        <div className="flex items-center justify-between mb-2">
-          <h3 className="text-sm font-semibold">Explorer</h3>
-          <div className="flex items-center space-x-1">
-            <button
-              onClick={refresh}
-              className="p-1 hover:bg-black rounded transition-colors"
-              title="Refresh"
-            >
-              <RefreshCw className="w-4 h-4" />
-            </button>
-            <button
-              className="p-1 hover:bg-black rounded transition-colors"
-              title="New File"
-            >
-              <Plus className="w-4 h-4" />
-            </button>
+          <div className="flex items-center justify-between mb-2">
+            <h3 className="text-sm font-semibold">Explorer</h3>
+            <div className="flex items-center space-x-1">
+              <button
+                onClick={refresh}
+                className="p-1 hover:bg-black rounded transition-colors"
+                title="Refresh"
+              >
+                <RefreshCw className="w-4 h-4" />
+              </button>
+              {selectedFile && (
+                <button
+                  onClick={handleDeleteSelected}
+                  className="p-1 hover:bg-black rounded transition-colors"
+                  title="Delete File"
+                >
+                  <Trash2 className="w-4 h-4" />
+                </button>
+              )}
+              <button
+                className="p-1 hover:bg-black rounded transition-colors"
+                title="New File"
+              >
+                <Plus className="w-4 h-4" />
+              </button>
+            </div>
           </div>
-        </div>
         
         {/* Search */}
         <div className="relative">

--- a/apps/desktop/src/stores/appStore.ts
+++ b/apps/desktop/src/stores/appStore.ts
@@ -94,6 +94,7 @@ interface AppState {
   navigateTo: (path: string) => void
   selectFile: (path: string) => void
   selectFiles: (paths: string[]) => void
+  deleteFile: (path: string) => Promise<void>
   
   // Error handling
   setError: (error: string | null) => void
@@ -431,7 +432,20 @@ export const useAppStore = create<AppState>((set, get) => ({
   selectFiles: (paths: string[]) => {
     set({ selectedFiles: paths })
   },
-  
+
+  deleteFile: async (path: string) => {
+    try {
+      const response = await invoke<{success: boolean, error?: string}>('delete_file', { path })
+      if (!response.success) {
+        throw new Error(response.error || 'Failed to delete file')
+      }
+    } catch (error) {
+      console.error('Failed to delete file:', error)
+      set({ error: error instanceof Error ? error.message : 'Failed to delete file' })
+      throw error
+    }
+  },
+
   // Error handling
   setError: (error: string | null) => {
     set({ error })


### PR DESCRIPTION
## Summary
- add `delete_file` Tauri command for removing files or directories under allowed roots
- wire deletion into Zustand store and file explorer UI

## Testing
- `pnpm test` *(fails: No tests found)*
- `pnpm lint` *(fails: ESLint couldn't find plugin "eslint-plugin-react")*
- `cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml` *(fails: missing system library gobject-2.0)*

------
https://chatgpt.com/codex/tasks/task_b_688d8c893a48832591f395fcb2ced3b9